### PR TITLE
added EuroPython spider to scrape speakers from official and unofficial pages

### DIFF
--- a/pycon_speakers/spiders/europython_eu.py
+++ b/pycon_speakers/spiders/europython_eu.py
@@ -10,12 +10,16 @@ from pycon_speakers.loaders import SpeakerLoader
 class EuroPython(Spider):
     name = 'europython.eu'
     years = '2006,2008,2009,2010,2011,2012,2013,2014'
-    start_url = 'http://lanyrd.com/{0}/europython/speakers/'
 
     def start_requests(self):
         years = [int(x) for x in self.years.split(',')]
         for year in years:
-            yield Request(self.start_url.format(year), meta={'cookiejar': year})
+            url = 'http://lanyrd.com/{0}/europython/speakers/'
+            callback = self.parse
+            if year >= 2011:
+                url = 'https://ep2013.europython.eu/ep{0}'
+                callback = self.parse_new
+            yield Request(url.format(year), callback=callback, meta={'cookiejar': year})
 
     def parse(self, response):
         sel = Selector(response)
@@ -30,3 +34,15 @@ class EuroPython(Spider):
         pages = sel.css('.pagination a::attr(href)').extract()
         for page in pages:
             yield Request(urljoin(response.url, page), meta=response.meta)
+
+    def parse_new(self, response):
+        sel = Selector(response)
+        speakers = sel.css('.archive .talk .speakers > .speaker')
+        for speaker in speakers:
+            il = SpeakerLoader(selector=speaker)
+            il.add_css('name', "span::text")
+            il.add_css('image_urls', "a > img::attr(src)", lambda x:
+                        [urljoin(response.url, y) for y in x])
+            il.add_value('year', str(response.meta['cookiejar']))
+            yield il.load_item()
+


### PR DESCRIPTION
Couldn't find speakers list on official EuroPython website for all years or may be I didn't dig enough to find them. Adding spider scraping speakers from lanyard.com (unofficial) and not sure if the source of speakers is legit but added this small spider anyway because I wanted to contribute.
